### PR TITLE
Cluster Bugfix getFeatureVectorCentroidDistancesMap

### DIFF
--- a/src/main/java/com/github/TKnudsen/DMandML/data/cluster/Cluster.java
+++ b/src/main/java/com/github/TKnudsen/DMandML/data/cluster/Cluster.java
@@ -50,7 +50,7 @@ public abstract class Cluster<T extends IDObject> implements ICluster<T>, IDObje
 	/**
 	 * data objects contained by the cluster
 	 */
-	private final Set<T> elements;
+	protected final Set<T> elements;
 
 	/**
 	 * distance measure for the calculation of centroid distances, etc.

--- a/src/main/java/com/github/TKnudsen/DMandML/data/cluster/numerical/NumericalFeatureVectorCluster.java
+++ b/src/main/java/com/github/TKnudsen/DMandML/data/cluster/numerical/NumericalFeatureVectorCluster.java
@@ -365,7 +365,9 @@ public class NumericalFeatureVectorCluster extends Cluster<NumericalFeatureVecto
 		return featureVectorCentroidDistancesLong;
 	}
 
+	
 	public Map<NumericalFeatureVector, Double> getFeatureVectorCentroidDistancesMap() {
+		elements.stream().filter(fv -> !featureVectorCentroidDistancesFV.containsKey(fv)).forEach(fv -> getCentroidDistance(fv)); //stellt sicher, das alle fv in der map sind
 		return featureVectorCentroidDistancesFV;
 	}
 


### PR DESCRIPTION
Es wird nun sicher gestellt, das für jedes Cluster tatsächlich der Centroid berechnet wird. Die ClassDistributionMinimizationStrategy benötigt diesen Bugfix um Funktionsfähig zu sein.